### PR TITLE
fix printed default path in mac

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -175,7 +175,7 @@ func dashPath() string {
 func mapConfig(cfgFile string) (config, string) {
 	if cfgFile == "" {
 		cfgFile = "default.yml"
-		createConfig(dashPath(), cfgFile, defaultConfig())
+		createConfig(dashPath(), cfgFile, defaultConfig(dashPath()))
 	}
 
 	// viper.AddConfigPath(home)
@@ -283,8 +283,8 @@ func (c config) KEdit() string {
 	return kEdit
 }
 
-func defaultConfig() string {
-	return `---
+func defaultConfig(dashPath string) string {
+	return fmt.Sprintf(`---
 general:
   refresh: 600
   keys:
@@ -293,7 +293,7 @@ general:
 
 
 projects:
-  - name: Default dashboard located at $HOME/.config/devdash/default.yml
+  - name: Default dashboard located at %s
     services:
       monitor:
         address: "https://thevaluable.dev"
@@ -305,5 +305,5 @@ projects:
                 - name: mon.box_availability
                   options:
                     title: " thevaluable.dev status "
-                    color: yellow`
+                    color: yellow`, filepath.Join(dashPath, "default.yml"))
 }


### PR DESCRIPTION
On mac the default path printed in the config is was correct, unfortunately, I spent some time understanding why before continue reading the Readme and understand it was OS dependent 😅
Before: 
![image](https://user-images.githubusercontent.com/4562878/127145884-16fc7db3-6b93-49d0-8c88-fd6937733c84.png)
FYI is 404 because i changed the url 

After: ![image](https://user-images.githubusercontent.com/4562878/127146151-21d2f918-71d2-4dcc-8cda-009b9e091c61.png)
